### PR TITLE
MicroBitAccelerometer: do not overwrite component id

### DIFF
--- a/source/drivers/MicroBitAccelerometer-bmx.cpp
+++ b/source/drivers/MicroBitAccelerometer-bmx.cpp
@@ -58,7 +58,6 @@ int MicroBitAccelerometer::configure()
 {
     // BMX_DEBUG("RUN BMX055 start\r\n");
 
-    id =    BMX055_ACC_ADDRESS<<1;
     wait_ms(100);
 
     i2c.start();


### PR DESCRIPTION
It seems that the class variable `id` (intended for use by the event
subsystem) was accidently overwritten by commit d386ce21.

This commit simply removes the assignment as it is not used by any code
within this class.